### PR TITLE
feat: add persistent login flow

### DIFF
--- a/clients/src/App.jsx
+++ b/clients/src/App.jsx
@@ -1,30 +1,37 @@
 import { Layout } from 'antd';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation, Navigate } from 'react-router-dom';
 import BottomNav from './components/BottomNav.jsx';
 import Login from './pages/Login.jsx';
 import AddReceipt from './pages/AddReceipt.jsx';
 import Receipts from './pages/Receipts.jsx';
 import ReceiptDetails from './pages/ReceiptDetails.jsx';
 import Settings from './pages/Settings.jsx';
+import { useAuth } from './stores/AuthContext.jsx';
 
 const App = () => {
   const location = useLocation();
-  const hideNav = location.pathname === '/login';
+  const { token } = useAuth();
+  const hideNav = !token || location.pathname === '/login';
 
   return (
     <Layout style={{ minHeight: '100vh', background: '#fff' }}>
       <Layout.Content style={{ paddingBottom: hideNav ? 0 : 56 }}>
         <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/" element={<AddReceipt />} />
-          <Route path="/add" element={<AddReceipt />} />
-          <Route path="/edit/:id" element={<AddReceipt />} />
-          <Route path="/receipts" element={<Receipts />} />
-          <Route path="/receipts/:id" element={<ReceiptDetails />} />
-          <Route path="/settings" element={<Settings />} />
+          <Route path="/login" element={!token ? <Login /> : <Navigate to="/" replace />} />
+          {token && (
+            <>
+              <Route path="/" element={<AddReceipt />} />
+              <Route path="/add" element={<AddReceipt />} />
+              <Route path="/edit/:id" element={<AddReceipt />} />
+              <Route path="/receipts" element={<Receipts />} />
+              <Route path="/receipts/:id" element={<ReceiptDetails />} />
+              <Route path="/settings" element={<Settings />} />
+            </>
+          )}
+          <Route path="*" element={<Navigate to={token ? '/' : '/login'} replace />} />
         </Routes>
       </Layout.Content>
-      {!hideNav && <BottomNav />}
+      {!hideNav && token && <BottomNav />}
     </Layout>
   );
 };

--- a/clients/src/api.js
+++ b/clients/src/api.js
@@ -1,0 +1,12 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export const authFetch = (path, options = {}) => {
+  const token = localStorage.getItem('token');
+  const headers = { ...options.headers };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return fetch(`${API_URL}${path}`, { ...options, headers });
+};
+
+export default API_URL;

--- a/clients/src/main.jsx
+++ b/clients/src/main.jsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import './index.css';
+import { AuthProvider } from './stores/AuthContext.jsx';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
 if ('serviceWorker' in navigator) {

--- a/clients/src/pages/Login.jsx
+++ b/clients/src/pages/Login.jsx
@@ -1,10 +1,44 @@
-import { Card, Tabs, Form, Input, Button } from 'antd';
+import { Card, Tabs, Form, Input, Button, message } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../stores/AuthContext.jsx';
+import API_URL from '../api.js';
 
 const Login = () => {
-  const [form] = Form.useForm();
+  const [loginForm] = Form.useForm();
+  const [registerForm] = Form.useForm();
+  const { login } = useAuth();
+  const navigate = useNavigate();
 
-  const onFinish = (values) => {
-    console.log('submit', values);
+  const handleLogin = async (values) => {
+    try {
+      const res = await fetch(`${API_URL}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error('login failed');
+      const data = await res.json();
+      login(data.token);
+      navigate('/');
+    } catch {
+      message.error('Login failed');
+    }
+  };
+
+  const handleRegister = async (values) => {
+    try {
+      const res = await fetch(`${API_URL}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (!res.ok) throw new Error('register failed');
+      const data = await res.json();
+      login(data.token);
+      navigate('/');
+    } catch {
+      message.error('Registration failed');
+    }
   };
 
   const items = [
@@ -12,9 +46,9 @@ const Login = () => {
       key: 'login',
       label: 'Login',
       children: (
-        <Form form={form} layout="vertical" onFinish={onFinish}>
-          <Form.Item name="email" rules={[{ required: true, message: 'Email' }]}>
-            <Input placeholder="Email" />
+        <Form form={loginForm} layout="vertical" onFinish={handleLogin}>
+          <Form.Item name="login" rules={[{ required: true, message: 'Login' }]}>
+            <Input placeholder="Login" />
           </Form.Item>
           <Form.Item name="password" rules={[{ required: true, message: 'Password' }]}>
             <Input.Password placeholder="Password" />
@@ -31,9 +65,9 @@ const Login = () => {
       key: 'register',
       label: 'Register',
       children: (
-        <Form layout="vertical" onFinish={onFinish}>
-          <Form.Item name="email" rules={[{ required: true, message: 'Email' }]}>
-            <Input placeholder="Email" />
+        <Form form={registerForm} layout="vertical" onFinish={handleRegister}>
+          <Form.Item name="login" rules={[{ required: true, message: 'Login' }]}>
+            <Input placeholder="Login" />
           </Form.Item>
           <Form.Item name="password" rules={[{ required: true, message: 'Password' }]}>
             <Input.Password placeholder="Password" />

--- a/clients/src/stores/AuthContext.jsx
+++ b/clients/src/stores/AuthContext.jsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+const AuthContext = createContext({ token: null, login: () => {}, logout: () => {} });
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) {
+      setToken(stored);
+    }
+  }, []);
+
+  const login = (newToken) => {
+    setToken(newToken);
+    localStorage.setItem('token', newToken);
+  };
+
+  const logout = () => {
+    setToken(null);
+    localStorage.removeItem('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useAuth = () => useContext(AuthContext);
+
+export default AuthContext;


### PR DESCRIPTION
## Summary
- add AuthContext to persist session token
- redirect unauthenticated users to login screen
- implement login/register calls storing token and skipping login on revisit

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6898eec7d8ac832187387240669d927f